### PR TITLE
Add settings dialog and preferences and implement Focus the applicati…

### DIFF
--- a/app.go
+++ b/app.go
@@ -31,6 +31,7 @@ func (app *Application) init() {
 	app.setupConfigDir()
 	config.init()
 	database.init()
+	clipboard.enforceMaxItems()
 }
 
 func (app *Application) setupConfigDir() {

--- a/clipboard.go
+++ b/clipboard.go
@@ -175,7 +175,26 @@ func (clipboard *Clipboard) saveToDatabase(content string, itemType byte) {
 	}
 
 	clipboard.recentContent = content
+	clipboard.enforceMaxItems()
 	ipc.notify()
+}
+
+func (clipboard *Clipboard) enforceMaxItems() {
+	if config.MaxClipboardItems <= 0 {
+		return
+	}
+
+	_, err := database.db.Exec(`
+DELETE FROM clipboard
+WHERE id NOT IN (
+	SELECT id
+	FROM clipboard
+	ORDER BY date_time DESC, id DESC
+	LIMIT ?
+)`, config.MaxClipboardItems)
+	if err != nil {
+		log.Printf("Failed to enforce clipboard item limit: %v", err)
+	}
 }
 
 func (clipboard *Clipboard) copy(id string, gtkApp *gtk.Application) {

--- a/clipboard.go
+++ b/clipboard.go
@@ -230,3 +230,13 @@ func (clipboard *Clipboard) removeFromDatabase(id string) {
 	}
 	database.db.Exec("DELETE FROM clipboard WHERE id=?", id)
 }
+
+func (clipboard *Clipboard) removeAllFromDatabase() {
+	_, err := database.db.Exec("DELETE FROM clipboard")
+	if err != nil {
+		log.Printf("Failed to clear clipboard database: %v", err)
+		return
+	}
+	clipboard.recentContent = ""
+	clipboard.itemCount = 0
+}

--- a/clipboard.go
+++ b/clipboard.go
@@ -32,7 +32,7 @@ func (clipboard *Clipboard) items(updateItemCount bool) ([]ClipboardItem, error)
 	var err error
 
 	if database.searchFilter != "" {
-		database.query = `SELECT id, type, date_time, content FROM clipboard WHERE type=1 AND content LIKE ? ORDER BY date_time DESC LIMIT 30`
+		database.query = `SELECT id, type, date_time, content FROM clipboard WHERE type=1 AND content LIKE ? ORDER BY date_time DESC`
 		rows, err = database.db.Query(database.query, "%"+database.searchFilter+"%")
 	} else {
 		database.query = database.queryBase

--- a/clipboard.go
+++ b/clipboard.go
@@ -26,17 +26,21 @@ type ClipboardItem struct {
 	itemType byte
 }
 
-func (clipboard *Clipboard) items(updateItemCount bool) ([]ClipboardItem, error) {
+func (clipboard *Clipboard) items(updateItemCount bool, limit, offset int) ([]ClipboardItem, error) {
 	var items []ClipboardItem
 	var rows *sql.Rows
 	var err error
 
+	if updateItemCount {
+		clipboard.count()
+	}
+
 	if database.searchFilter != "" {
-		database.query = `SELECT id, type, date_time, content FROM clipboard WHERE type=1 AND content LIKE ? ORDER BY date_time DESC`
-		rows, err = database.db.Query(database.query, "%"+database.searchFilter+"%")
+		database.query = `SELECT id, type, date_time, content FROM clipboard WHERE type=1 AND content LIKE ? ORDER BY date_time DESC LIMIT ? OFFSET ?`
+		rows, err = database.db.Query(database.query, "%"+database.searchFilter+"%", limit, offset)
 	} else {
-		database.query = database.queryBase
-		rows, err = database.db.Query(database.query)
+		database.query = database.queryBase + " LIMIT ? OFFSET ?"
+		rows, err = database.db.Query(database.query, limit, offset)
 	}
 
 	if err != nil {
@@ -52,15 +56,16 @@ func (clipboard *Clipboard) items(updateItemCount bool) ([]ClipboardItem, error)
 		items = append(items, item)
 	}
 
-	if updateItemCount {
-		clipboard.count()
-	}
-
 	return items, nil
 }
 
 func (clipboard *Clipboard) count() {
-	rowTotalItemsCount := database.db.QueryRow("SELECT COUNT(*) as total_items FROM clipboard")
+	var rowTotalItemsCount *sql.Row
+	if database.searchFilter != "" {
+		rowTotalItemsCount = database.db.QueryRow("SELECT COUNT(*) as total_items FROM clipboard WHERE type=1 AND content LIKE ?", "%"+database.searchFilter+"%")
+	} else {
+		rowTotalItemsCount = database.db.QueryRow("SELECT COUNT(*) as total_items FROM clipboard")
+	}
 	rowTotalItemsCount.Scan(&clipboard.itemCount)
 }
 

--- a/config.go
+++ b/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Config struct {
-	Comment     string `json:"comment"`
-	CloseOnCopy bool   `json:"close_on_copy"`
-	file        string `json:"-"`
+	Comment           string `json:"comment"`
+	CloseOnCopy       bool   `json:"close_on_copy"`
+	FocusWindowOnOpen bool   `json:"focus_window_on_open"`
+	file              string `json:"-"`
 }
 
 func (config *Config) init() {
@@ -30,12 +31,14 @@ func (config *Config) isExist() bool {
 func (config *Config) setDefaults() {
 	config.Comment = "Documentation: " + app.helpURL
 	config.CloseOnCopy = false
+	config.FocusWindowOnOpen = false
 }
 
 func (config *Config) save() {
 	configData := &Config{
-		Comment:     config.Comment,
-		CloseOnCopy: config.CloseOnCopy,
+		Comment:           config.Comment,
+		CloseOnCopy:       config.CloseOnCopy,
+		FocusWindowOnOpen: config.FocusWindowOnOpen,
 	}
 	configJSON, err := json.MarshalIndent(configData, "", "  ")
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Config struct {
-	Comment     string `json:"comment"`
-	CloseOnCopy bool   `json:"close_on_copy"`
-	file        string `json:"-"`
+	Comment           string `json:"comment"`
+	CloseOnCopy       bool   `json:"close_on_copy"`
+	MaxClipboardItems int    `json:"max_clipboard_items"`
+	file              string `json:"-"`
 }
 
 func (config *Config) init() {
@@ -30,12 +31,14 @@ func (config *Config) isExist() bool {
 func (config *Config) setDefaults() {
 	config.Comment = "Documentation: " + app.helpURL
 	config.CloseOnCopy = false
+	config.MaxClipboardItems = 500
 }
 
 func (config *Config) save() {
 	configData := &Config{
-		Comment:     config.Comment,
-		CloseOnCopy: config.CloseOnCopy,
+		Comment:           config.Comment,
+		CloseOnCopy:       config.CloseOnCopy,
+		MaxClipboardItems: config.MaxClipboardItems,
 	}
 	configJSON, err := json.MarshalIndent(configData, "", "  ")
 	if err != nil {
@@ -59,5 +62,9 @@ func (config *Config) load() {
 	if err != nil {
 		log.Printf("Failed to parse config file: %v", err)
 		return
+	}
+	if config.MaxClipboardItems <= 0 {
+		config.MaxClipboardItems = 500
+		config.save()
 	}
 }

--- a/database.go
+++ b/database.go
@@ -15,7 +15,7 @@ type Database struct {
 
 func (database *Database) init() error {
 	database.searchFilter = ""
-	database.queryBase = "SELECT id, type, date_time, content FROM clipboard ORDER BY date_time DESC LIMIT 30"
+	database.queryBase = "SELECT id, type, date_time, content FROM clipboard ORDER BY date_time DESC"
 	if err := database.connect(); err != nil {
 		return err
 	}

--- a/gui.go
+++ b/gui.go
@@ -536,13 +536,50 @@ func (gui *GUI) showSettingsDialog(parent *gtk.ApplicationWindow) {
 		config.save()
 	})
 
+	clearClipboardButton := gtk.NewButtonWithLabel("Clear Clipboard")
+	clearClipboardButton.AddCSSClass("destructive-action")
+	clearClipboardButton.ConnectClicked(func() {
+		gui.showClearClipboardDialog(settingsDialog)
+	})
+
 	contentArea.Append(runOnStartupCheckButton)
 	contentArea.Append(closeOnCopyCheckButton)
 	contentArea.Append(focusWindowCheckButton)
+	contentArea.Append(clearClipboardButton)
 	settingsDialog.ConnectResponse(func(responseId int) {
 		settingsDialog.Close()
 	})
 	settingsDialog.SetVisible(true)
+}
+
+func (gui *GUI) showClearClipboardDialog(parent *gtk.Dialog) {
+	confirmDialog := gtk.NewDialog()
+	confirmDialog.SetTransientFor(&parent.Window)
+	confirmDialog.SetModal(true)
+	confirmDialog.SetTitle("Clear Clipboard")
+	confirmDialog.AddButton("Cancel", int(gtk.ResponseCancel))
+	confirmDialog.AddButton("Clear", int(gtk.ResponseAccept))
+	confirmDialog.SetDefaultResponse(int(gtk.ResponseCancel))
+
+	contentArea := confirmDialog.ContentArea()
+	contentArea.SetMarginTop(16)
+	contentArea.SetMarginBottom(16)
+	contentArea.SetMarginStart(16)
+	contentArea.SetMarginEnd(16)
+
+	messageLabel := gtk.NewLabel("Clear all saved clipboard items?")
+	messageLabel.SetWrap(true)
+	messageLabel.SetXAlign(0)
+	contentArea.Append(messageLabel)
+
+	confirmDialog.ConnectResponse(func(responseId int) {
+		if responseId == int(gtk.ResponseAccept) {
+			clipboard.removeAllFromDatabase()
+			gui.updateClipboardRows(true)
+		}
+		confirmDialog.Close()
+	})
+	confirmDialog.SetVisible(true)
 }
 
 func (gui *GUI) setupAboutAction(gtkApp *gtk.Application) {

--- a/gui.go
+++ b/gui.go
@@ -30,6 +30,8 @@ type GUI struct {
 	searchBar          *gtk.SearchBar
 	searchToggleButton *gtk.ToggleButton
 	window             *gtk.ApplicationWindow
+	runOnStartupAction *gio.SimpleAction
+	closeOnCopyAction  *gio.SimpleAction
 }
 
 func (gui *GUI) init() {
@@ -52,10 +54,14 @@ func (gui *GUI) activate(gtkApp *gtk.Application) {
 	gui.window.SetApplication(gtkApp)
 	gui.setupCSS()
 	gui.updateClipboardRows(true)
-	gui.focusClipboardItemByIndex(0)
 	gui.window.SetVisible(true)
+	if config.FocusWindowOnOpen {
+		gui.window.Present()
+		gui.focusClipboardItemByIndex(0)
+	}
 	gui.setupEvents(gtkApp)
 	gui.setupShortcutsAction(gtkApp)
+	gui.setupSettingsAction(gtkApp)
 	gui.setupAboutAction(gtkApp)
 	gui.setupActionRunOnStartup(gtkApp)
 	gui.setupCloseOnCopy(gtkApp)
@@ -476,6 +482,69 @@ func (gui *GUI) showShortcutsWindow(parent *gtk.ApplicationWindow) {
 	shortcutsWindow.SetVisible(true)
 }
 
+func (gui *GUI) setupSettingsAction(gtkApp *gtk.Application) {
+	settingsAction := gio.NewSimpleAction("settings", nil)
+	settingsAction.ConnectActivate(func(parameter *glib.Variant) {
+		gui.showSettingsDialog(gui.window)
+	})
+	gtkApp.AddAction(settingsAction)
+}
+
+func (gui *GUI) showSettingsDialog(parent *gtk.ApplicationWindow) {
+	settingsDialog := gtk.NewDialog()
+	settingsDialog.SetTransientFor(&parent.Window)
+	settingsDialog.SetModal(true)
+	settingsDialog.SetTitle("Settings")
+	settingsDialog.SetDefaultSize(420, 120)
+	settingsDialog.AddButton("Close", int(gtk.ResponseClose))
+
+	contentArea := settingsDialog.ContentArea()
+	contentArea.SetMarginTop(16)
+	contentArea.SetMarginBottom(16)
+	contentArea.SetMarginStart(16)
+	contentArea.SetMarginEnd(16)
+	contentArea.SetSpacing(8)
+
+	runOnStartupCheckButton := gtk.NewCheckButtonWithLabel("Run on Startup")
+	runOnStartupCheckButton.SetActive(gui.startupEntryControl("check"))
+	runOnStartupCheckButton.ConnectToggled(func() {
+		runOnStartup := runOnStartupCheckButton.Active()
+		if runOnStartup {
+			gui.startupEntryControl("add")
+		} else {
+			gui.startupEntryControl("remove")
+		}
+		if gui.runOnStartupAction != nil {
+			gui.runOnStartupAction.SetState(glib.NewVariantBoolean(runOnStartup))
+		}
+	})
+
+	closeOnCopyCheckButton := gtk.NewCheckButtonWithLabel("Close on Copy")
+	closeOnCopyCheckButton.SetActive(config.CloseOnCopy)
+	closeOnCopyCheckButton.ConnectToggled(func() {
+		config.CloseOnCopy = closeOnCopyCheckButton.Active()
+		config.save()
+		if gui.closeOnCopyAction != nil {
+			gui.closeOnCopyAction.SetState(glib.NewVariantBoolean(config.CloseOnCopy))
+		}
+	})
+
+	focusWindowCheckButton := gtk.NewCheckButtonWithLabel("Focus the application window when opening it")
+	focusWindowCheckButton.SetActive(config.FocusWindowOnOpen)
+	focusWindowCheckButton.ConnectToggled(func() {
+		config.FocusWindowOnOpen = focusWindowCheckButton.Active()
+		config.save()
+	})
+
+	contentArea.Append(runOnStartupCheckButton)
+	contentArea.Append(closeOnCopyCheckButton)
+	contentArea.Append(focusWindowCheckButton)
+	settingsDialog.ConnectResponse(func(responseId int) {
+		settingsDialog.Close()
+	})
+	settingsDialog.SetVisible(true)
+}
+
 func (gui *GUI) setupAboutAction(gtkApp *gtk.Application) {
 	aboutAction := gio.NewSimpleAction("about", nil)
 	aboutAction.ConnectActivate(func(parameter *glib.Variant) {
@@ -504,6 +573,7 @@ func (gui *GUI) setupActionRunOnStartup(gtkApp *gtk.Application) {
 	actionRunOnStartup.ConnectActivate(func(parameter *glib.Variant) {
 		gui.handleRunOnStartup(actionRunOnStartup)
 	})
+	gui.runOnStartupAction = actionRunOnStartup
 	gtkApp.AddAction(actionRunOnStartup)
 	if !hasStartupEntry {
 		glib.TimeoutAdd(1000, func() bool {
@@ -519,6 +589,7 @@ func (gui *GUI) setupCloseOnCopy(gtkApp *gtk.Application) {
 	actionCloseOnCopy.ConnectActivate(func(parameter *glib.Variant) {
 		gui.handleCloseOnCopy(actionCloseOnCopy)
 	})
+	gui.closeOnCopyAction = actionCloseOnCopy
 	gtkApp.AddAction(actionCloseOnCopy)
 }
 
@@ -572,7 +643,7 @@ func (gui *GUI) showAddToStartupToast() {
 	toastBox.SetMarginEnd(20)
 	toastBox.AddCSSClass("toast")
 
-	label := gtk.NewLabel("Go the menu to add Clyp to the system startup.")
+	label := gtk.NewLabel("Go to Settings to add Clyp to the system startup.")
 	label.SetHAlign(gtk.AlignCenter)
 	toastBox.Append(label)
 

--- a/gui.go
+++ b/gui.go
@@ -56,6 +56,7 @@ func (gui *GUI) activate(gtkApp *gtk.Application) {
 	gui.window.SetVisible(true)
 	gui.setupEvents(gtkApp)
 	gui.setupShortcutsAction(gtkApp)
+	gui.setupSettingsAction(gtkApp)
 	gui.setupAboutAction(gtkApp)
 	gui.setupActionRunOnStartup(gtkApp)
 	gui.setupCloseOnCopy(gtkApp)
@@ -474,6 +475,54 @@ func (gui *GUI) showShortcutsWindow(parent *gtk.ApplicationWindow) {
 	shortcutsWindow.SetTransientFor(&parent.Window)
 	shortcutsWindow.SetModal(true)
 	shortcutsWindow.SetVisible(true)
+}
+
+func (gui *GUI) setupSettingsAction(gtkApp *gtk.Application) {
+	settingsAction := gio.NewSimpleAction("settings", nil)
+	settingsAction.ConnectActivate(func(parameter *glib.Variant) {
+		gui.showSettingsDialog(gui.window)
+	})
+	gtkApp.AddAction(settingsAction)
+}
+
+func (gui *GUI) showSettingsDialog(parent *gtk.ApplicationWindow) {
+	settingsDialog := gtk.NewDialog()
+	settingsDialog.SetTransientFor(&parent.Window)
+	settingsDialog.SetModal(true)
+	settingsDialog.SetTitle("Settings")
+	settingsDialog.SetDefaultSize(420, 120)
+	settingsDialog.AddButton("Close", int(gtk.ResponseClose))
+
+	contentArea := settingsDialog.ContentArea()
+	contentArea.SetMarginTop(16)
+	contentArea.SetMarginBottom(16)
+	contentArea.SetMarginStart(16)
+	contentArea.SetMarginEnd(16)
+	contentArea.SetSpacing(8)
+
+	maxItemsBox := gtk.NewBox(gtk.OrientationHorizontal, 12)
+	maxItemsLabel := gtk.NewLabel("Maximum saved clipboard items")
+	maxItemsLabel.SetXAlign(0)
+	maxItemsLabel.SetHExpand(true)
+
+	maxItemsSpinButton := gtk.NewSpinButtonWithRange(1, 100000, 1)
+	maxItemsSpinButton.SetValue(float64(config.MaxClipboardItems))
+	maxItemsSpinButton.SetNumeric(true)
+	maxItemsSpinButton.ConnectValueChanged(func() {
+		config.MaxClipboardItems = maxItemsSpinButton.ValueAsInt()
+		config.save()
+		clipboard.enforceMaxItems()
+		gui.updateClipboardRows(true)
+	})
+
+	maxItemsBox.Append(maxItemsLabel)
+	maxItemsBox.Append(maxItemsSpinButton)
+	contentArea.Append(maxItemsBox)
+
+	settingsDialog.ConnectResponse(func(responseId int) {
+		settingsDialog.Close()
+	})
+	settingsDialog.SetVisible(true)
 }
 
 func (gui *GUI) setupAboutAction(gtkApp *gtk.Application) {

--- a/gui.go
+++ b/gui.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/diamondburned/gotk4/pkg/gdk/v4"
 	"github.com/diamondburned/gotk4/pkg/gio/v2"
@@ -150,10 +151,12 @@ func (gui *GUI) addTextRow(item ClipboardItem) {
 	box.SetMarginEnd(12)
 	box.AddCSSClass("item-box")
 
-	if len(item.content) > 100 {
-		item.content = item.content[:100] + "\n..."
+	content := strings.ToValidUTF8(item.content, "")
+	contentRunes := []rune(content)
+	if len(contentRunes) > 100 {
+		content = string(contentRunes[:100]) + "\n..."
 	}
-	contentLabel := gtk.NewLabel(item.content)
+	contentLabel := gtk.NewLabel(content)
 	contentLabel.SetWrap(true)
 	contentLabel.SetWrapMode(pango.WrapWordChar)
 	contentLabel.SetXAlign(0)

--- a/gui.go
+++ b/gui.go
@@ -25,14 +25,19 @@ var (
 	watcherFile string
 )
 
+const clipboardItemsPageSize = 30
+
 type GUI struct {
 	clipboardItemsList *gtk.ListBox
+	clipboardScrolled  *gtk.ScrolledWindow
 	searchEntry        *gtk.SearchEntry
 	searchBar          *gtk.SearchBar
 	searchToggleButton *gtk.ToggleButton
 	window             *gtk.ApplicationWindow
 	runOnStartupAction *gio.SimpleAction
 	closeOnCopyAction  *gio.SimpleAction
+	loadedItems        int
+	loadingItems       bool
 }
 
 func (gui *GUI) init() {
@@ -49,6 +54,7 @@ func (gui *GUI) activate(gtkApp *gtk.Application) {
 	builder := gtk.NewBuilderFromString(uiXML)
 	gui.window = builder.GetObject("gtk_window").Cast().(*gtk.ApplicationWindow)
 	gui.clipboardItemsList = builder.GetObject("clipboard_list").Cast().(*gtk.ListBox)
+	gui.clipboardScrolled = builder.GetObject("clipboard_scrolled_window").Cast().(*gtk.ScrolledWindow)
 	gui.searchEntry = builder.GetObject("search_entry").Cast().(*gtk.SearchEntry)
 	gui.searchBar = builder.GetObject("search_bar").Cast().(*gtk.SearchBar)
 	gui.searchToggleButton = builder.GetObject("search_toggle_button").Cast().(*gtk.ToggleButton)
@@ -119,13 +125,31 @@ func (gui *GUI) updateTitle(itemsShowing, itemsTotal string) {
 
 func (gui *GUI) updateClipboardRows(updateItemCount bool) {
 	gui.clipboardItemsList.RemoveAll()
-	items, err := clipboard.items(updateItemCount)
+	gui.loadedItems = 0
+	gui.loadClipboardRows(updateItemCount)
+}
+
+func (gui *GUI) loadClipboardRows(updateItemCount bool) {
+	if gui.loadingItems {
+		return
+	}
+	if gui.loadedItems > 0 && gui.loadedItems >= clipboard.itemCount {
+		return
+	}
+
+	gui.loadingItems = true
+	defer func() {
+		gui.loadingItems = false
+	}()
+
+	items, err := clipboard.items(updateItemCount, clipboardItemsPageSize, gui.loadedItems)
 	if err != nil {
 		log.Printf("Error getting clipboard items: %v", err)
 		return
 	}
 
-	gui.updateTitle(strconv.Itoa(len(items)), strconv.Itoa(clipboard.itemCount))
+	gui.loadedItems += len(items)
+	gui.updateTitle(strconv.Itoa(gui.loadedItems), strconv.Itoa(clipboard.itemCount))
 
 	if len(items) == 0 {
 		return
@@ -254,6 +278,7 @@ func (gui *GUI) scaleImageToFit(image *gtk.Image, texture *gdk.Texture, maxSize 
 func (gui *GUI) setupEvents(gtkApp *gtk.Application) {
 	gui.setupAppEvents(gtkApp)
 	gui.setupClipBoardListEvents(gtkApp)
+	gui.setupScrollEvents()
 	gui.setupWindowEvents()
 	gui.setupSearchBarEvents()
 }
@@ -286,8 +311,8 @@ func (gui *GUI) setupClipBoardListEvents(gtkApp *gtk.Application) {
 
 		if keyval == gdk.KEY_Delete {
 			selectedRow := gui.clipboardItemsList.SelectedRow()
-			selectedRowIndex := selectedRow.Index()
 			if selectedRow != nil {
+				selectedRowIndex := selectedRow.Index()
 				clipboard.removeFromDatabase(selectedRow.Name())
 				gui.updateClipboardRows(true)
 				gui.focusClipboardItemByIndex(selectedRowIndex)
@@ -328,6 +353,21 @@ func (gui *GUI) setupClipBoardListEvents(gtkApp *gtk.Application) {
 	gui.clipboardItemsList.AddController(clipboardListkeyController)
 	gui.clipboardItemsList.AddController(gestureClick)
 
+}
+
+func (gui *GUI) setupScrollEvents() {
+	gui.clipboardScrolled.ConnectEdgeReached(func(pos gtk.PositionType) {
+		if pos == gtk.PosBottom {
+			gui.loadClipboardRows(false)
+		}
+	})
+
+	adjustment := gui.clipboardScrolled.VAdjustment()
+	adjustment.ConnectValueChanged(func() {
+		if adjustment.Value()+adjustment.PageSize() >= adjustment.Upper()-48 {
+			gui.loadClipboardRows(false)
+		}
+	})
 }
 
 func (gui *GUI) setupWindowEvents() {
@@ -416,13 +456,13 @@ func (gui *GUI) setupSearchBarEvents() {
 	gui.searchEntry.ConnectSearchChanged(func() {
 		if gui.searchEntry.Text() == "" {
 			database.searchFilter = ""
-			gui.updateClipboardRows(false)
+			gui.updateClipboardRows(true)
 			gui.focusClipboardItemByIndex(0)
 			gui.searchBarControl("hide")
 			return
 		}
 		database.searchFilter = gui.searchEntry.Text()
-		gui.updateClipboardRows(false)
+		gui.updateClipboardRows(true)
 	})
 	gui.searchBar.ConnectEntry(gui.searchEntry)
 	gui.searchToggleButton.ConnectToggled(func() {

--- a/ipc.go
+++ b/ipc.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net"
 	"os"
+
+	"github.com/diamondburned/gotk4/pkg/glib/v2"
 )
 
 type IPC struct{}
@@ -42,8 +44,10 @@ func (ipc *IPC) listen() {
 			log.Printf("Failed to read from socket: %v", err)
 			continue
 		}
-		gui.updateClipboardRows(true)
-		gui.focusClipboardItemByIndex(0)
+		glib.IdleAdd(func() {
+			gui.updateClipboardRows(true)
+			gui.focusClipboardItemByIndex(0)
+		})
 		conn.Close()
 	}
 }

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1,5 +1,5 @@
 .titlebar {
-    background: var(--theme_bg_color);
+    background: @theme_bg_color;
     border-bottom: none;
     box-shadow: none;
 }
@@ -9,7 +9,7 @@
 }
 
 .clipboard-list {
-    background: var(--theme_bg_color);
+    background: @theme_bg_color;
 }
 
 .clipboard-list, .clipboard-list * {
@@ -25,8 +25,8 @@
 }
 
 .toast {
-    background: var(--theme_selected_bg_color);
-    color: var(--theme_selected_fg_color);
+    background: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
     border-radius: 8px;
     padding: 8px 12px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);

--- a/resources/ui/main.ui
+++ b/resources/ui/main.ui
@@ -147,18 +147,12 @@
   <menu id="primary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Run on Startup</attribute>
-        <attribute name="action">app.run_on_startup</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">Close on Copy</attribute>
-        <attribute name="action">app.close_on_copy</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
         <attribute name="label" translatable="yes">Shortcuts</attribute>
         <attribute name="action">app.shortcuts</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Settings</attribute>
+        <attribute name="action">app.settings</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">About</attribute>

--- a/resources/ui/main.ui
+++ b/resources/ui/main.ui
@@ -161,6 +161,10 @@
         <attribute name="action">app.shortcuts</attribute>
       </item>
       <item>
+        <attribute name="label" translatable="yes">Settings</attribute>
+        <attribute name="action">app.settings</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">About</attribute>
         <attribute name="action">app.about</attribute>
       </item>

--- a/resources/ui/main.ui
+++ b/resources/ui/main.ui
@@ -51,7 +51,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkScrolledWindow" id="clipboard_scrolled_window">
             <property name="halign">fill</property>
             <property name="valign">fill</property>
             <property name="vexpand">true</property>


### PR DESCRIPTION
  ## Summary

Adds a Settings dialog for application preferences and implements an option to focus the saved clipboard list when opening Clyp.

  ## Changes

  - Added a new `Settings` item to the main menu.
  - Moved `Run on Startup` into the Settings dialog.
  - Added a new preference: `Close on Copy` (which only existed in the configuration file).
  - Added a new preference: `Focus the application window when opening it`.
  - Persisted the new focus preference in `config.json` as `focus_window_on_open`.
  - When enabled, Clyp presents the application window and focuses the first saved clipboard item on startup.
  - Updated the startup reminder toast to point users to Settings.
