### PR TITLE
Feat/focus limit clear

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -175,7 +175,26 @@ func (clipboard *Clipboard) saveToDatabase(content string, itemType byte) {
 	}
 
 	clipboard.recentContent = content
+	clipboard.enforceMaxItems()
 	ipc.notify()
+}
+
+func (clipboard *Clipboard) enforceMaxItems() {
+	if config.MaxClipboardItems <= 0 {
+		return
+	}
+
+	_, err := database.db.Exec(`
+DELETE FROM clipboard
+WHERE id NOT IN (
+	SELECT id
+	FROM clipboard
+	ORDER BY date_time DESC, id DESC
+	LIMIT ?
+)`, config.MaxClipboardItems)
+	if err != nil {
+		log.Printf("Failed to enforce clipboard item limit: %v", err)
+	}
 }
 
 func (clipboard *Clipboard) copy(id string, gtkApp *gtk.Application) {

--- a/clipboard.go
+++ b/clipboard.go
@@ -230,3 +230,13 @@ func (clipboard *Clipboard) removeFromDatabase(id string) {
 	}
 	database.db.Exec("DELETE FROM clipboard WHERE id=?", id)
 }
+
+func (clipboard *Clipboard) removeAllFromDatabase() {
+	_, err := database.db.Exec("DELETE FROM clipboard")
+	if err != nil {
+		log.Printf("Failed to clear clipboard database: %v", err)
+		return
+	}
+	clipboard.recentContent = ""
+	clipboard.itemCount = 0
+}

--- a/config.go
+++ b/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Config struct {
-	Comment     string `json:"comment"`
-	CloseOnCopy bool   `json:"close_on_copy"`
-	file        string `json:"-"`
+	Comment           string `json:"comment"`
+	CloseOnCopy       bool   `json:"close_on_copy"`
+	FocusWindowOnOpen bool   `json:"focus_window_on_open"`
+	file              string `json:"-"`
 }
 
 func (config *Config) init() {
@@ -30,12 +31,14 @@ func (config *Config) isExist() bool {
 func (config *Config) setDefaults() {
 	config.Comment = "Documentation: " + app.helpURL
 	config.CloseOnCopy = false
+	config.FocusWindowOnOpen = false
 }
 
 func (config *Config) save() {
 	configData := &Config{
-		Comment:     config.Comment,
-		CloseOnCopy: config.CloseOnCopy,
+		Comment:           config.Comment,
+		CloseOnCopy:       config.CloseOnCopy,
+		FocusWindowOnOpen: config.FocusWindowOnOpen,
 	}
 	configJSON, err := json.MarshalIndent(configData, "", "  ")
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Config struct {
-	Comment     string `json:"comment"`
-	CloseOnCopy bool   `json:"close_on_copy"`
-	file        string `json:"-"`
+	Comment           string `json:"comment"`
+	CloseOnCopy       bool   `json:"close_on_copy"`
+	MaxClipboardItems int    `json:"max_clipboard_items"`
+	file              string `json:"-"`
 }
 
 func (config *Config) init() {
@@ -30,12 +31,14 @@ func (config *Config) isExist() bool {
 func (config *Config) setDefaults() {
 	config.Comment = "Documentation: " + app.helpURL
 	config.CloseOnCopy = false
+	config.MaxClipboardItems = 500
 }
 
 func (config *Config) save() {
 	configData := &Config{
-		Comment:     config.Comment,
-		CloseOnCopy: config.CloseOnCopy,
+		Comment:           config.Comment,
+		CloseOnCopy:       config.CloseOnCopy,
+		MaxClipboardItems: config.MaxClipboardItems,
 	}
 	configJSON, err := json.MarshalIndent(configData, "", "  ")
 	if err != nil {
@@ -59,5 +62,9 @@ func (config *Config) load() {
 	if err != nil {
 		log.Printf("Failed to parse config file: %v", err)
 		return
+	}
+	if config.MaxClipboardItems <= 0 {
+		config.MaxClipboardItems = 500
+		config.save()
 	}
 }

--- a/gui.go
+++ b/gui.go
@@ -536,13 +536,50 @@ func (gui *GUI) showSettingsDialog(parent *gtk.ApplicationWindow) {
 		config.save()
 	})
 
+	clearClipboardButton := gtk.NewButtonWithLabel("Clear Clipboard")
+	clearClipboardButton.AddCSSClass("destructive-action")
+	clearClipboardButton.ConnectClicked(func() {
+		gui.showClearClipboardDialog(settingsDialog)
+	})
+
 	contentArea.Append(runOnStartupCheckButton)
 	contentArea.Append(closeOnCopyCheckButton)
 	contentArea.Append(focusWindowCheckButton)
+	contentArea.Append(clearClipboardButton)
 	settingsDialog.ConnectResponse(func(responseId int) {
 		settingsDialog.Close()
 	})
 	settingsDialog.SetVisible(true)
+}
+
+func (gui *GUI) showClearClipboardDialog(parent *gtk.Dialog) {
+	confirmDialog := gtk.NewDialog()
+	confirmDialog.SetTransientFor(&parent.Window)
+	confirmDialog.SetModal(true)
+	confirmDialog.SetTitle("Clear Clipboard")
+	confirmDialog.AddButton("Cancel", int(gtk.ResponseCancel))
+	confirmDialog.AddButton("Clear", int(gtk.ResponseAccept))
+	confirmDialog.SetDefaultResponse(int(gtk.ResponseCancel))
+
+	contentArea := confirmDialog.ContentArea()
+	contentArea.SetMarginTop(16)
+	contentArea.SetMarginBottom(16)
+	contentArea.SetMarginStart(16)
+	contentArea.SetMarginEnd(16)
+
+	messageLabel := gtk.NewLabel("Clear all saved clipboard items?")
+	messageLabel.SetWrap(true)
+	messageLabel.SetXAlign(0)
+	contentArea.Append(messageLabel)
+
+	confirmDialog.ConnectResponse(func(responseId int) {
+		if responseId == int(gtk.ResponseAccept) {
+			clipboard.removeAllFromDatabase()
+			gui.updateClipboardRows(true)
+		}
+		confirmDialog.Close()
+	})
+	confirmDialog.SetVisible(true)
 }
 
 func (gui *GUI) setupAboutAction(gtkApp *gtk.Application) {

--- a/gui.go
+++ b/gui.go
@@ -30,6 +30,8 @@ type GUI struct {
 	searchBar          *gtk.SearchBar
 	searchToggleButton *gtk.ToggleButton
 	window             *gtk.ApplicationWindow
+	runOnStartupAction *gio.SimpleAction
+	closeOnCopyAction  *gio.SimpleAction
 }
 
 func (gui *GUI) init() {
@@ -52,10 +54,14 @@ func (gui *GUI) activate(gtkApp *gtk.Application) {
 	gui.window.SetApplication(gtkApp)
 	gui.setupCSS()
 	gui.updateClipboardRows(true)
-	gui.focusClipboardItemByIndex(0)
 	gui.window.SetVisible(true)
+	if config.FocusWindowOnOpen {
+		gui.window.Present()
+		gui.focusClipboardItemByIndex(0)
+	}
 	gui.setupEvents(gtkApp)
 	gui.setupShortcutsAction(gtkApp)
+	gui.setupSettingsAction(gtkApp)
 	gui.setupAboutAction(gtkApp)
 	gui.setupActionRunOnStartup(gtkApp)
 	gui.setupCloseOnCopy(gtkApp)
@@ -476,6 +482,69 @@ func (gui *GUI) showShortcutsWindow(parent *gtk.ApplicationWindow) {
 	shortcutsWindow.SetVisible(true)
 }
 
+func (gui *GUI) setupSettingsAction(gtkApp *gtk.Application) {
+	settingsAction := gio.NewSimpleAction("settings", nil)
+	settingsAction.ConnectActivate(func(parameter *glib.Variant) {
+		gui.showSettingsDialog(gui.window)
+	})
+	gtkApp.AddAction(settingsAction)
+}
+
+func (gui *GUI) showSettingsDialog(parent *gtk.ApplicationWindow) {
+	settingsDialog := gtk.NewDialog()
+	settingsDialog.SetTransientFor(&parent.Window)
+	settingsDialog.SetModal(true)
+	settingsDialog.SetTitle("Settings")
+	settingsDialog.SetDefaultSize(420, 120)
+	settingsDialog.AddButton("Close", int(gtk.ResponseClose))
+
+	contentArea := settingsDialog.ContentArea()
+	contentArea.SetMarginTop(16)
+	contentArea.SetMarginBottom(16)
+	contentArea.SetMarginStart(16)
+	contentArea.SetMarginEnd(16)
+	contentArea.SetSpacing(8)
+
+	runOnStartupCheckButton := gtk.NewCheckButtonWithLabel("Run on Startup")
+	runOnStartupCheckButton.SetActive(gui.startupEntryControl("check"))
+	runOnStartupCheckButton.ConnectToggled(func() {
+		runOnStartup := runOnStartupCheckButton.Active()
+		if runOnStartup {
+			gui.startupEntryControl("add")
+		} else {
+			gui.startupEntryControl("remove")
+		}
+		if gui.runOnStartupAction != nil {
+			gui.runOnStartupAction.SetState(glib.NewVariantBoolean(runOnStartup))
+		}
+	})
+
+	closeOnCopyCheckButton := gtk.NewCheckButtonWithLabel("Close on Copy")
+	closeOnCopyCheckButton.SetActive(config.CloseOnCopy)
+	closeOnCopyCheckButton.ConnectToggled(func() {
+		config.CloseOnCopy = closeOnCopyCheckButton.Active()
+		config.save()
+		if gui.closeOnCopyAction != nil {
+			gui.closeOnCopyAction.SetState(glib.NewVariantBoolean(config.CloseOnCopy))
+		}
+	})
+
+	focusWindowCheckButton := gtk.NewCheckButtonWithLabel("Focus the application window when opening it")
+	focusWindowCheckButton.SetActive(config.FocusWindowOnOpen)
+	focusWindowCheckButton.ConnectToggled(func() {
+		config.FocusWindowOnOpen = focusWindowCheckButton.Active()
+		config.save()
+	})
+
+	contentArea.Append(runOnStartupCheckButton)
+	contentArea.Append(closeOnCopyCheckButton)
+	contentArea.Append(focusWindowCheckButton)
+	settingsDialog.ConnectResponse(func(responseId int) {
+		settingsDialog.Close()
+	})
+	settingsDialog.SetVisible(true)
+}
+
 func (gui *GUI) setupAboutAction(gtkApp *gtk.Application) {
 	aboutAction := gio.NewSimpleAction("about", nil)
 	aboutAction.ConnectActivate(func(parameter *glib.Variant) {
@@ -504,6 +573,7 @@ func (gui *GUI) setupActionRunOnStartup(gtkApp *gtk.Application) {
 	actionRunOnStartup.ConnectActivate(func(parameter *glib.Variant) {
 		gui.handleRunOnStartup(actionRunOnStartup)
 	})
+	gui.runOnStartupAction = actionRunOnStartup
 	gtkApp.AddAction(actionRunOnStartup)
 	if !hasStartupEntry {
 		glib.TimeoutAdd(1000, func() bool {
@@ -519,6 +589,7 @@ func (gui *GUI) setupCloseOnCopy(gtkApp *gtk.Application) {
 	actionCloseOnCopy.ConnectActivate(func(parameter *glib.Variant) {
 		gui.handleCloseOnCopy(actionCloseOnCopy)
 	})
+	gui.closeOnCopyAction = actionCloseOnCopy
 	gtkApp.AddAction(actionCloseOnCopy)
 }
 
@@ -572,7 +643,7 @@ func (gui *GUI) showAddToStartupToast() {
 	toastBox.SetMarginEnd(20)
 	toastBox.AddCSSClass("toast")
 
-	label := gtk.NewLabel("Go the menu to add Clyp to the system startup.")
+	label := gtk.NewLabel("Go to Settings to add Clyp to the system startup.")
 	label.SetHAlign(gtk.AlignCenter)
 	toastBox.Append(label)
 

--- a/gui.go
+++ b/gui.go
@@ -56,6 +56,7 @@ func (gui *GUI) activate(gtkApp *gtk.Application) {
 	gui.window.SetVisible(true)
 	gui.setupEvents(gtkApp)
 	gui.setupShortcutsAction(gtkApp)
+	gui.setupSettingsAction(gtkApp)
 	gui.setupAboutAction(gtkApp)
 	gui.setupActionRunOnStartup(gtkApp)
 	gui.setupCloseOnCopy(gtkApp)
@@ -474,6 +475,54 @@ func (gui *GUI) showShortcutsWindow(parent *gtk.ApplicationWindow) {
 	shortcutsWindow.SetTransientFor(&parent.Window)
 	shortcutsWindow.SetModal(true)
 	shortcutsWindow.SetVisible(true)
+}
+
+func (gui *GUI) setupSettingsAction(gtkApp *gtk.Application) {
+	settingsAction := gio.NewSimpleAction("settings", nil)
+	settingsAction.ConnectActivate(func(parameter *glib.Variant) {
+		gui.showSettingsDialog(gui.window)
+	})
+	gtkApp.AddAction(settingsAction)
+}
+
+func (gui *GUI) showSettingsDialog(parent *gtk.ApplicationWindow) {
+	settingsDialog := gtk.NewDialog()
+	settingsDialog.SetTransientFor(&parent.Window)
+	settingsDialog.SetModal(true)
+	settingsDialog.SetTitle("Settings")
+	settingsDialog.SetDefaultSize(420, 120)
+	settingsDialog.AddButton("Close", int(gtk.ResponseClose))
+
+	contentArea := settingsDialog.ContentArea()
+	contentArea.SetMarginTop(16)
+	contentArea.SetMarginBottom(16)
+	contentArea.SetMarginStart(16)
+	contentArea.SetMarginEnd(16)
+	contentArea.SetSpacing(8)
+
+	maxItemsBox := gtk.NewBox(gtk.OrientationHorizontal, 12)
+	maxItemsLabel := gtk.NewLabel("Maximum saved clipboard items")
+	maxItemsLabel.SetXAlign(0)
+	maxItemsLabel.SetHExpand(true)
+
+	maxItemsSpinButton := gtk.NewSpinButtonWithRange(1, 100000, 1)
+	maxItemsSpinButton.SetValue(float64(config.MaxClipboardItems))
+	maxItemsSpinButton.SetNumeric(true)
+	maxItemsSpinButton.ConnectValueChanged(func() {
+		config.MaxClipboardItems = maxItemsSpinButton.ValueAsInt()
+		config.save()
+		clipboard.enforceMaxItems()
+		gui.updateClipboardRows(true)
+	})
+
+	maxItemsBox.Append(maxItemsLabel)
+	maxItemsBox.Append(maxItemsSpinButton)
+	contentArea.Append(maxItemsBox)
+
+	settingsDialog.ConnectResponse(func(responseId int) {
+		settingsDialog.Close()
+	})
+	settingsDialog.SetVisible(true)
 }
 
 func (gui *GUI) setupAboutAction(gtkApp *gtk.Application) {

--- a/resources/ui/main.ui
+++ b/resources/ui/main.ui
@@ -147,18 +147,12 @@
   <menu id="primary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Run on Startup</attribute>
-        <attribute name="action">app.run_on_startup</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">Close on Copy</attribute>
-        <attribute name="action">app.close_on_copy</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
         <attribute name="label" translatable="yes">Shortcuts</attribute>
         <attribute name="action">app.shortcuts</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Settings</attribute>
+        <attribute name="action">app.settings</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">About</attribute>

--- a/resources/ui/main.ui
+++ b/resources/ui/main.ui
@@ -161,6 +161,10 @@
         <attribute name="action">app.shortcuts</attribute>
       </item>
       <item>
+        <attribute name="label" translatable="yes">Settings</attribute>
+        <attribute name="action">app.settings</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">About</attribute>
         <attribute name="action">app.about</attribute>
       </item>


### PR DESCRIPTION
  This PR groups all improvements implemented after `e036f0e` into a single branch. I also opened separate PRs for some of these changes, in case you prefer to review or merge only specific
  features individually. This PR includes the full set of improvements together.

  ## Changes

  ### Settings Dialog

  - Added a new `Settings` item to the main menu.
  - Added a Settings dialog for application preferences.
  - Moved existing preference controls into Settings:
    - `Run on Startup`
    - `Close on Copy`
  - Updated the startup reminder message to point users to Settings.

  ### Focus Window on Open

  - Added a new configuration option:
    - `focus_window_on_open`
  - Added a Settings checkbox:
    - `Focus the application window when opening it`
  - When enabled, Clyp presents the application window and focuses the first saved clipboard item when opening.

  ### Clear Clipboard

  - Added a `Clear Clipboard` action in Settings.
  - Added a confirmation dialog before clearing saved clipboard entries.
  - Implemented backend cleanup for all saved clipboard items.
  - Refreshes the clipboard list and item count after clearing.
  - Resets the in-memory recent clipboard content after cleanup.

  ### Clipboard Item Limit

  - Added a new configuration option:
    - `max_clipboard_items`
  - Default value is `500`.
  - Existing config files are automatically updated with the default value if the field is missing or invalid.
  - Enforces the configured limit after saving new clipboard items by removing the oldest entries beyond the limit.
  - Added a Settings numeric control:
    - `Maximum saved clipboard items`
  - Applies the new limit immediately when changed in Settings.

  ## Notes

  Separate PRs were opened for individual features as well, so you can choose to merge only the pieces you want. This PR combines all of the implemented improvements in one place.
